### PR TITLE
Add InputChannelSelector Transforms for StaticImage Data.

### DIFF
--- a/mlutils/data/transforms.py
+++ b/mlutils/data/transforms.py
@@ -312,6 +312,7 @@ class SelectInputChannel(StaticTransform):
 
     def __call__(self, x):
         key_vals = {k: v for k, v in zip(x._fields, x)}
-        key_vals["images"] = (lambda img: img[:, (self.grab_channel,)] if len(img.shape) == 4 else img[(self.grab_channel,)])(key_vals['images'])
+        img = key_vals["images"]
+        key_vals["images"] = img[:, (self.grab_channel,)] if len(img.shape) == 4 else img[(self.grab_channel,)]
         return x.__class__(**key_vals)
 


### PR DESCRIPTION
This transform allows the user to select an InputChannel from the "images" property of the StaticImageSet. All other channels will be disregarded.