### PR TITLE
Update measures.py

### DIFF
--- a/mlutils/measures.py
+++ b/mlutils/measures.py
@@ -150,6 +150,6 @@ def corr(y1, y2, axis=-1, eps=1e-8, **kwargs):
     Returns: correlation vector
 
     """
-    y1 = (y1 - y1.mean(axis=axis, keepdims=True)) / (y1.std(axis=axis, keepdims=True, ddof=1) + eps)
-    y2 = (y2 - y2.mean(axis=axis, keepdims=True)) / (y2.std(axis=axis, keepdims=True, ddof=1) + eps)
+    y1 = (y1 - y1.mean(axis=axis, keepdims=True)) / (y1.std(axis=axis, keepdims=True, ddof=0) + eps)
+    y2 = (y2 - y2.mean(axis=axis, keepdims=True)) / (y2.std(axis=axis, keepdims=True, ddof=0) + eps)
     return (y1 * y2).mean(axis=axis, **kwargs)


### PR DESCRIPTION
Actually if computing sample standard deviation with ddof=0, correlation is correct only if we divide the `(y1 * y2)` by `n-1` instead of `n` (which is what `.mean` does. So, to correctly compute correlation, it's actually correct to use `ddof=0` in the standard deviation computation.