### PR TITLE
Update requirements to fix failing CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch
 tqdm
 pandas
 h5py
+scipy


### PR DESCRIPTION
This PR adds `scipy` to the requirements. Currently the CI is failing because `scipy` is not installed during the run even though it is required.
