### PR TITLE
Eval state fix

### DIFF
--- a/neuralpredictors/training.py
+++ b/neuralpredictors/training.py
@@ -218,9 +218,8 @@ def device_state(model, device):
     """
     # infer the original device based on the device the first parameter is placed on
     original_device = next(model.parameters()).device
-
     # create device spec
-    device = torch.device(device)
+    device = torch.device("cuda:0") if device == "cuda" else torch.device(device)
     if device.type == "cuda" and device.index >= torch.cuda.device_count():
         # fall back to using CPU
         warnings.warn("Incompatible CUDA spec. Falling back to CPU usage")

--- a/neuralpredictors/training.py
+++ b/neuralpredictors/training.py
@@ -219,6 +219,7 @@ def device_state(model, device):
     # infer the original device based on the device the first parameter is placed on
     original_device = next(model.parameters()).device
     # create device spec
+    # if device is simply "cuda", then device.index will evaluate to one, and the if statement will error out.
     device = torch.device("cuda:0") if device == "cuda" else torch.device(device)
     if device.type == "cuda" and device.index >= torch.cuda.device_count():
         # fall back to using CPU


### PR DESCRIPTION
This PR fixes a bug. The user can specify a cuda device in two ways, either by `device = "cuda:0"`, which is recommended practice. But the user can also be lazy by running `device = "cuda"`. This will by default use the 0th-device.
But, specifying the device in a lazy way will result in 
```
print(device.index)
>>> None
```

and then this line (L223)
```
device.type == "cuda" and device.index >= torch.cuda.device_count():
```
will fail. With this fix, it will no longer fail.