### PR TITLE
Fix bug in MultiReadoutSharedParametersBase

### DIFF
--- a/neuralpredictors/layers/readouts/multi_readout.py
+++ b/neuralpredictors/layers/readouts/multi_readout.py
@@ -105,7 +105,10 @@ class MultiReadoutSharedParametersBase(MultiReadoutBase):
                     "match_ids": readout_kwargs["shared_match_ids"][data_key],
                     "shared_grid": None if i == 0 else self[first_data_key].shared_grid,
                 }
-            _ = [readout_kwargs.pop(kwarg, None) for kwarg in ["share_transform", "share_grid", "grid_mean_predictor_type"]]
+            _ = [
+                readout_kwargs.pop(kwarg, None)
+                for kwarg in ["share_transform", "share_grid", "grid_mean_predictor_type"]
+            ]
 
         if "share_features" in readout_kwargs:
             if readout_kwargs["share_features"]:

--- a/neuralpredictors/layers/readouts/multi_readout.py
+++ b/neuralpredictors/layers/readouts/multi_readout.py
@@ -91,22 +91,22 @@ class MultiReadoutSharedParametersBase(MultiReadoutBase):
         i,
         data_key,
         first_data_key,
+        grid_mean_predictor=None,
+        grid_mean_predictor_type=None,
         share_transform=None,
         share_grid=None,
-        grid_mean_predictor=None,
         share_features=None,
         **kwargs
     ):
         readout_kwargs = kwargs.copy()
 
         if grid_mean_predictor:
-            if readout_kwargs["grid_mean_predictor_type"] == "cortex":
+            if grid_mean_predictor_type == "cortex":
                 readout_kwargs["source_grid"] = readout_kwargs["source_grids"][data_key]
+                readout_kwargs["grid_mean_predictor"] = grid_mean_predictor
             else:
-                raise KeyError(
-                    "grid mean predictor {} does not exist".format(readout_kwargs["grid_mean_predictor_type"])
-                )
-            if share_transform is not None:
+                raise KeyError("grid mean predictor {} does not exist".format(grid_mean_predictor_type))
+            if share_transform:
                 readout_kwargs["shared_transform"] = None if i == 0 else self[first_data_key].mu_transform
 
         elif share_grid:

--- a/neuralpredictors/layers/readouts/multi_readout.py
+++ b/neuralpredictors/layers/readouts/multi_readout.py
@@ -86,37 +86,40 @@ class MultiReadoutSharedParametersBase(MultiReadoutBase):
     For more information on which parameters can be shared, refer for example to the FullGaussian2d readout
     """
 
-    def prepare_readout_kwargs(self, i, data_key, first_data_key, **kwargs):
+    def prepare_readout_kwargs(
+        self,
+        i,
+        data_key,
+        first_data_key,
+        share_transform=None,
+        share_grid=None,
+        grid_mean_predictor=None,
+        share_features=None,
+        **kwargs
+    ):
         readout_kwargs = kwargs.copy()
 
-        if "grid_mean_predictor" in readout_kwargs:
-            if readout_kwargs["grid_mean_predictor"] is not None:
-                if readout_kwargs["grid_mean_predictor_type"] == "cortex":
-                    readout_kwargs["source_grid"] = readout_kwargs["source_grids"][data_key]
-                else:
-                    raise KeyError(
-                        "grid mean predictor {} does not exist".format(readout_kwargs["grid_mean_predictor_type"])
-                    )
-                if readout_kwargs["share_transform"]:
-                    readout_kwargs["shared_transform"] = None if i == 0 else self[first_data_key].mu_transform
-
-            elif readout_kwargs["share_grid"]:
-                readout_kwargs["shared_grid"] = {
-                    "match_ids": readout_kwargs["shared_match_ids"][data_key],
-                    "shared_grid": None if i == 0 else self[first_data_key].shared_grid,
-                }
-            _ = [
-                readout_kwargs.pop(kwarg, None)
-                for kwarg in ["share_transform", "share_grid", "grid_mean_predictor_type"]
-            ]
-
-        if "share_features" in readout_kwargs:
-            if readout_kwargs["share_features"]:
-                readout_kwargs["shared_features"] = {
-                    "match_ids": readout_kwargs["shared_match_ids"][data_key],
-                    "shared_features": None if i == 0 else self[first_data_key].shared_features,
-                }
+        if grid_mean_predictor:
+            if readout_kwargs["grid_mean_predictor_type"] == "cortex":
+                readout_kwargs["source_grid"] = readout_kwargs["source_grids"][data_key]
             else:
-                readout_kwargs["shared_features"] = None
-            del readout_kwargs["share_features"]
+                raise KeyError(
+                    "grid mean predictor {} does not exist".format(readout_kwargs["grid_mean_predictor_type"])
+                )
+            if share_transform is not None:
+                readout_kwargs["shared_transform"] = None if i == 0 else self[first_data_key].mu_transform
+
+        elif share_grid:
+            readout_kwargs["shared_grid"] = {
+                "match_ids": readout_kwargs["shared_match_ids"][data_key],
+                "shared_grid": None if i == 0 else self[first_data_key].shared_grid,
+            }
+
+        if share_features:
+            readout_kwargs["shared_features"] = {
+                "match_ids": readout_kwargs["shared_match_ids"][data_key],
+                "shared_features": None if i == 0 else self[first_data_key].shared_features,
+            }
+        else:
+            readout_kwargs["shared_features"] = None
         return readout_kwargs

--- a/neuralpredictors/layers/readouts/multi_readout.py
+++ b/neuralpredictors/layers/readouts/multi_readout.py
@@ -93,9 +93,9 @@ class MultiReadoutSharedParametersBase(MultiReadoutBase):
         first_data_key,
         grid_mean_predictor=None,
         grid_mean_predictor_type=None,
-        share_transform=None,
-        share_grid=None,
-        share_features=None,
+        share_transform=False,
+        share_grid=False,
+        share_features=False,
         **kwargs
     ):
         readout_kwargs = kwargs.copy()

--- a/neuralpredictors/layers/readouts/multi_readout.py
+++ b/neuralpredictors/layers/readouts/multi_readout.py
@@ -105,10 +105,7 @@ class MultiReadoutSharedParametersBase(MultiReadoutBase):
                     "match_ids": readout_kwargs["shared_match_ids"][data_key],
                     "shared_grid": None if i == 0 else self[first_data_key].shared_grid,
                 }
-
-            del readout_kwargs["share_transform"]
-            del readout_kwargs["share_grid"]
-            del readout_kwargs["grid_mean_predictor_type"]
+            [readout_kwargs.pop(kwarg, None) for kwarg in ["share_transform", "share_grid", "grid_mean_predictor_type"]]
 
         if "share_features" in readout_kwargs:
             if readout_kwargs["share_features"]:

--- a/neuralpredictors/layers/readouts/multi_readout.py
+++ b/neuralpredictors/layers/readouts/multi_readout.py
@@ -105,7 +105,7 @@ class MultiReadoutSharedParametersBase(MultiReadoutBase):
                     "match_ids": readout_kwargs["shared_match_ids"][data_key],
                     "shared_grid": None if i == 0 else self[first_data_key].shared_grid,
                 }
-            [readout_kwargs.pop(kwarg, None) for kwarg in ["share_transform", "share_grid", "grid_mean_predictor_type"]]
+            _ = [readout_kwargs.pop(kwarg, None) for kwarg in ["share_transform", "share_grid", "grid_mean_predictor_type"]]
 
         if "share_features" in readout_kwargs:
             if readout_kwargs["share_features"]:


### PR DESCRIPTION
The MultiReadoutSharedParametersBase is used per default when initializing the MultipleGaussian2d.
It assumes that the kwargs of the shared parameters, such as `share_transform` are passed to the MultiReadout. But this is not necessarily the case (for example, when a normal MultipleGaussian is initialized).
I therefore changed the `del` functions to `pop` methods.

If we make MultiReadoutSharedParametersBase to only work with readout that should have parameters that are shared, we could do something like this in the init instead, and get around the problem (and introduce new problems instead):

```
class MultipleFullGaussian2d(MultiReadoutBase):
    _base_readout = FullGaussian2d
   
class MultipleFullGaussian2dShared(MultiReadoutSharedParametersBase):
    _base_readout = FullGaussian2d
```