### PR TITLE
Fix package not being installed in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src/neuralpredictors
 
 RUN python3 -m pip install --upgrade pip &&\
     python3 -m pip install mypy==$(cat mypy_version.txt) &&\
-    python3 -m pip install -e /src/neuralpredictors
+    python3 -m pip install --no-use-pep517 -e /src/neuralpredictors
 
 
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
The package was not being installed in the Docker container. This made the
tests fail because they could not import the package. Adding the
`--no-use-pep517` option to `pip install` resolves the issue.
