### PR TITLE
handle case when there is no NaN value in CutVideos

### DIFF
--- a/neuralpredictors/data/transforms.py
+++ b/neuralpredictors/data/transforms.py
@@ -653,7 +653,8 @@ class CutVideos(MovieTransform):
             idx = []
             for k in x._fields:
                 loc = getattr(x, k)
-                idx.append(np.argwhere(np.isnan(loc))[:, self.frame_axis[k]].min())
+                nans = np.argwhere(np.isnan(loc))[:, self.frame_axis[k]]
+                idx.append(nans.min() if nans.size else loc.shape[self.frame_axis[k]])
             idx = np.arange(self.min_frame, min(idx))
             return x.__class__(
                 **{


### PR DESCRIPTION
- `np.argwhere(np.isnan(loc))[:, self.frame_axis[k]].min()` would cause an error when there is no NaN values in `loc` (calling `.min()` on an empty array).
- added a quick fix to check if `np.argwhere(np.isnan(loc))[:, self.frame_axis[k]]` is empty, if so, set `idx` to the length of `loc`, otherwise return `min()` value.