### PR TITLE
fix that cannot correctly set bn layer channels

### DIFF
--- a/neuralpredictors/layers/cores/conv3d.py
+++ b/neuralpredictors/layers/cores/conv3d.py
@@ -166,7 +166,7 @@ class Basic3dCore(Core3d, nn.Module):
             padding=(0, input_kernel[1] // 2, input_kernel[2] // 2) if self.padding else 0,
         )
 
-        self.add_bn_layer(layer=layer, hidden_channels=hidden_channels[0])
+        self.add_bn_layer(layer=layer, hidden_channels=self.hidden_channels[0])
 
         if layers > 1 or self.final_nonlinearity:
             if hidden_nonlinearities == "adaptive_elu":
@@ -191,7 +191,7 @@ class Basic3dCore(Core3d, nn.Module):
                 padding=(0, self.hidden_kernel[l][1] // 2, self.hidden_kernel[l][2] // 2) if self.padding else 0,
             )
 
-            self.add_bn_layer(layer=layer, hidden_channels=hidden_channels[l + 1])
+            self.add_bn_layer(layer=layer, hidden_channels=self.hidden_channels[l + 1])
 
             if self.final_nonlinearity or l < self.layers:
                 if hidden_nonlinearities == "adaptive_elu":
@@ -386,7 +386,7 @@ class Factorized3dCore(Core3d, nn.Module):
             dilation=(self.temporal_dilation, 1, 1),
         )
 
-        self.add_bn_layer(layer=layer, hidden_channels=hidden_channels[0])
+        self.add_bn_layer(layer=layer, hidden_channels=self.hidden_channels[0])
 
         if layers > 1 or final_nonlin:
             if hidden_nonlinearities == "adaptive_elu":
@@ -417,7 +417,7 @@ class Factorized3dCore(Core3d, nn.Module):
                 dilation=(self.hidden_temporal_dilation[l], 1, 1),
             )
 
-            self.add_bn_layer(layer=layer, hidden_channels=hidden_channels[l + 1])
+            self.add_bn_layer(layer=layer, hidden_channels=self.hidden_channels[l + 1])
 
             if final_nonlin or l < self.layers:
                 if hidden_nonlinearities == "adaptive_elu":


### PR DESCRIPTION
When setting the `hidden_channels` as a integer, function `add_bn_layer` was passed a error parameter which caused TypeError as below

```
Traceback (most recent call last):
  File "/***/sensorium_2023/main.py", line 143, in <module>
    full_3d_model = make_video_model(
  File "/***/sensorium_2023/sensorium_2023/sensorium/models/make_model.py", line 141, in make_video_model
    core = Basic3dCore(**core_dict)
  File "/***/conda_envs/envs/sensorium/lib/python3.9/site-packages/neuralpredictors/layers/cores/conv3d.py", line 169, in __init__
    self.add_bn_layer(layer=layer, hidden_channels=hidden_channels[0])
TypeError: 'int' object is not subscriptable
```