### PR TITLE
Fixes bug that would add a redundant scale layer to batchnorm layer with affine=True

### DIFF
--- a/neuralpredictors/layers/cores/conv2d.py
+++ b/neuralpredictors/layers/cores/conv2d.py
@@ -6,6 +6,7 @@ try:
     from collections import Iterable
 except:
     from collections.abc import Iterable
+
 from functools import partial
 
 import torch
@@ -223,7 +224,11 @@ class Stacked2dCore(Core, nn.Module):
                     not self.batch_norm_scale or (self.penultimate_layer_built() and not self.final_batchnorm_scale)
                 ):
                     layer["bias"] = self.bias_layer_cls(hidden_channels)
-                elif self.batch_norm_scale and not (self.penultimate_layer_built() and not self.final_batchnorm_scale):
+                elif (
+                    self.batch_norm_scale
+                    and not self.bias
+                    and not (self.penultimate_layer_built() and not self.final_batchnorm_scale)
+                ):
                     layer["scale"] = self.scale_layer_cls(hidden_channels)
 
     def add_activation(self, layer):


### PR DESCRIPTION
When creating a model with these params

```
batch_norm=True,
independent_bn_bias=False,
bias=True,
batch_norm_scale=True,
```

we would see redundant scale parameters (because in `affine=True` in `BatchNorm1d`:

```
      (norm): RotationEquivariantBatchNorm2D(
        (batch_norm): BatchNorm1d(8, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      )
      (scale): RotationEquivariantScale2DLayer()
```

Code to reproduce:

```
from neuralpredictors.layers.cores import RotationEquivariant2dCore
core = RotationEquivariant2dCore(
    pad_input=False,
    stack=-1,
    layers=4,
    hidden_channels=8,
    num_rotations=8,
    input_kern=13,
    hidden_kern=5,
    gamma_input=6,
    batch_norm=True,
    independent_bn_bias=False,
    bias=True,
    batch_norm_scale=True,
    final_batchnorm_scale=False,
    input_channels=1,
)
print(core)
```