### PR TITLE
Adds possibility to specify batch_norm, bias and batch_norm_scale for each layer

### DIFF
--- a/neuralpredictors/layers/cores/conv2d.py
+++ b/neuralpredictors/layers/cores/conv2d.py
@@ -122,6 +122,12 @@ class Stacked2dCore(Core, nn.Module):
         if depth_separable and attention_conv:
             raise ValueError("depth_separable and attention_conv can not both be true")
 
+        # TODO
+        print(batch_norm)
+        print(batch_norm_scale)
+        print(final_batchnorm_scale)
+        print(bias)
+
         self.batch_norm = batch_norm if isinstance(batch_norm, Iterable) else [batch_norm] * layers
 
         if isinstance(batch_norm_scale, bool):
@@ -133,8 +139,10 @@ class Stacked2dCore(Core, nn.Module):
             self.batch_norm_scale = [batch_norm_scale] * (layers - 1) + [final_batchnorm_scale]
         else:
             logger.warning("Passed `batch_norm_scale` as an iterable, ignoring `final_batchnorm_scale`.")
+            self.batch_norm_scale = batch_norm_scale
 
         self.bias = bias if isinstance(bias, Iterable) else [bias] * layers
+
         self.independent_bn_bias = independent_bn_bias
         if self.independent_bn_bias and not all(self.bias) and not all(self.batch_norm_scale):
             warnings.warn(

--- a/neuralpredictors/layers/cores/conv2d.py
+++ b/neuralpredictors/layers/cores/conv2d.py
@@ -218,7 +218,7 @@ class Stacked2dCore(Core, nn.Module):
             layer["norm"] = self.batchnorm_layer_cls(hidden_channels, momentum=self.momentum, affine=bias and scale)
             if bias and not scale:
                 layer["bias"] = self.bias_layer_cls(hidden_channels)
-            else:  # not bias and scale
+            elif not bias and scale:
                 layer["scale"] = self.scale_layer_cls(hidden_channels)
 
     def penultimate_layer_built(self):

--- a/neuralpredictors/layers/cores/conv2d.py
+++ b/neuralpredictors/layers/cores/conv2d.py
@@ -122,12 +122,6 @@ class Stacked2dCore(Core, nn.Module):
         if depth_separable and attention_conv:
             raise ValueError("depth_separable and attention_conv can not both be true")
 
-        # TODO
-        print(batch_norm)
-        print(batch_norm_scale)
-        print(final_batchnorm_scale)
-        print(bias)
-
         self.batch_norm = batch_norm if isinstance(batch_norm, Iterable) else [batch_norm] * layers
 
         if isinstance(batch_norm_scale, bool):


### PR DESCRIPTION
To specify batch norm and its properties for each layer individually, this PR changes the attributes `batch_norm` `bias` `batch_norm_scale` and the according class members to lists. 

Backwards-compatibility is ensured.

Also includes #215 which should be merged first.