### PR TITLE
shifter init fix

### DIFF
--- a/neuralpredictors/layers/shifters/mlp.py
+++ b/neuralpredictors/layers/shifters/mlp.py
@@ -31,13 +31,18 @@ class MLP(Shifter):
         feat.extend([nn.Linear(prev_output, 2, bias=bias), nn.Tanh()])
         self.mlp = nn.Sequential(*feat)
 
+        self.initialize()
+
     def regularizer(self):
         return 0
 
     def initialize(self):
-        for linear_layer in [p for p in self.parameters() if isinstance(p, nn.Linear)]:
-            xavier_normal(linear_layer.weight)
-
+        for layer in self.mlp:
+            if isinstance(layer, nn.Linear):
+                xavier_normal_(layer.weight)
+                if layer.bias is not None:
+                    nn.init.zeros_(layer.bias)
+        
     def forward(self, pupil_center, trial_idx=None):
         if trial_idx is not None:
             pupil_center = torch.cat((pupil_center, trial_idx), dim=1)
@@ -73,9 +78,7 @@ class MLPShifter(ModuleDict):
             self.add_module(k, MLP(input_channels, hidden_channels_shifter, shift_layers, bias))
 
     def initialize(self, **kwargs):
-        logger.info("Ignoring input {} when initializing {}".format(repr(kwargs), self.__class__.__name__))
-        for linear_layer in [p for p in self.parameters() if isinstance(p, nn.Linear)]:
-            xavier_normal(linear_layer.weight)
+        pass
 
     def regularizer(self, data_key):
         return self[data_key].regularizer() * self.gamma_shifter

--- a/neuralpredictors/layers/shifters/mlp.py
+++ b/neuralpredictors/layers/shifters/mlp.py
@@ -78,5 +78,9 @@ class MLPShifter(ModuleDict):
         for k in data_keys:
             self.add_module(k, MLP(input_channels, hidden_channels_shifter, shift_layers, bias))
 
+    def initialize(self, **kwargs):
+         for k in self:
+             self[k].initialize()
+
     def regularizer(self, data_key):
         return self[data_key].regularizer() * self.gamma_shifter

--- a/neuralpredictors/layers/shifters/mlp.py
+++ b/neuralpredictors/layers/shifters/mlp.py
@@ -3,7 +3,7 @@ import logging
 import torch
 from torch import nn
 from torch.nn import ModuleDict
-from torch.nn.init import xavier_normal
+from torch.nn.init import xavier_normal_
 
 from .base import Shifter
 
@@ -37,11 +37,12 @@ class MLP(Shifter):
         return 0
 
     def initialize(self):
-        for layer in self.mlp:
-            if isinstance(layer, nn.Linear):
-                xavier_normal_(layer.weight)
-                if layer.bias is not None:
-                    nn.init.zeros_(layer.bias)
+        with torch.no_grad():
+            for layer in self.mlp:
+                if isinstance(layer, nn.Linear):
+                    xavier_normal_(layer.weight)
+                    if layer.bias is not None:
+                        nn.init.zeros_(layer.bias)
         
     def forward(self, pupil_center, trial_idx=None):
         if trial_idx is not None:
@@ -76,9 +77,6 @@ class MLPShifter(ModuleDict):
         self.gamma_shifter = gamma_shifter
         for k in data_keys:
             self.add_module(k, MLP(input_channels, hidden_channels_shifter, shift_layers, bias))
-
-    def initialize(self, **kwargs):
-        pass
 
     def regularizer(self, data_key):
         return self[data_key].regularizer() * self.gamma_shifter

--- a/test/test_shifter_init.py
+++ b/test/test_shifter_init.py
@@ -1,0 +1,12 @@
+import torch
+from torch import nn
+from unittest.mock import patch
+
+from neuralpredictors.layers.shifters import MLP
+
+def test_xavier_initialization_is_used():
+    with patch("neuralpredictors.layers.shifters.mlp.xavier_normal_") as mock_xavier:
+        MLP(shift_layers=3)
+
+    # One Linear layer per shift layer
+    assert mock_xavier.call_count == 3

--- a/test/test_shifter_init.py
+++ b/test/test_shifter_init.py
@@ -1,5 +1,3 @@
-import torch
-from torch import nn
 from unittest.mock import patch
 
 from neuralpredictors.layers.shifters import MLP


### PR DESCRIPTION
shifter initialization function was never called and it checked if parameters are instances of nn.Linear which is always wrong because they are tensors.